### PR TITLE
Indexable waveform sequence property

### DIFF
--- a/adafruit_drv2605.py
+++ b/adafruit_drv2605.py
@@ -239,6 +239,7 @@ class Effect:
     """Class for adding an effect to the DRV2605 waveform sequence."""
     def __init__(self, effect_id):
         self._effect_id = 0
+        # pylint: disable=invalid-name
         self.id = effect_id
 
     @property
@@ -247,11 +248,13 @@ class Effect:
         return self._effect_id
 
     @property
+    # pylint: disable=invalid-name
     def id(self):
         """Return the effect ID."""
         return self._effect_id
 
     @id.setter
+    # pylint: disable=invalid-name
     def id(self, effect_id):
         """Set the effect ID."""
         if not 0 <= effect_id <= 123:

--- a/adafruit_drv2605.py
+++ b/adafruit_drv2605.py
@@ -236,7 +236,7 @@ class DRV2605:
 
 
 class Effect:
-    """Class for adding an effect to the DRV2605 waveform sequence."""
+    """DRV2605 waveform sequence effect."""
     def __init__(self, effect_id):
         self._effect_id = 0
         # pylint: disable=invalid-name
@@ -244,13 +244,13 @@ class Effect:
 
     @property
     def raw_value(self):
-        """Return the raw effect ID."""
+        """Raw effect ID."""
         return self._effect_id
 
     @property
     # pylint: disable=invalid-name
     def id(self):
-        """Return the effect ID."""
+        """Effect ID."""
         return self._effect_id
 
     @id.setter
@@ -262,7 +262,6 @@ class Effect:
         self._effect_id = effect_id
 
     def __repr__(self):
-        """Return a string representation of the Effect class."""
         return "{}({})".format(type(self).__qualname__, self.id)
 
 
@@ -278,7 +277,7 @@ class Pause:
 
     @property
     def raw_value(self):
-        """Return the raw pause duration."""
+        """Raw pause duration."""
         return self._duration
 
     @property
@@ -294,7 +293,6 @@ class Pause:
         self._duration = 0x80 | duration
 
     def __repr__(self):
-        """Return a string representation of the Pause class."""
         return "{}({})".format(type(self).__qualname__, self.duration)
 
 

--- a/examples/drv2605_simpletest.py
+++ b/examples/drv2605_simpletest.py
@@ -19,11 +19,10 @@ drv = adafruit_drv2605.DRV2605(i2c)
 effect = 1
 while True:
     print('Playing effect #{0}'.format(effect))
-    drv.set_waveform(effect)  # Select the effect on slot 0.
-    # Optionally you can assign effects to up to 7 different slots to combine
-    # them in interesting ways.  Use the slot keyword and specify a slot 0 to 6
-    # (0 is the default).
-    #drv.set_waveform(effect, slot=1)
+    drv.sequence[0] = effect  # Set the effect on slot 0.
+    # You can assign effects to up to 7 different slots to combine
+    # them in interesting ways. Index the sequence property with a
+    # slot number 0 to 6.
     drv.play()  # Play the effect.
     time.sleep(0.5)
     # Increment effect ID and wrap back around to 1.

--- a/examples/drv2605_simpletest.py
+++ b/examples/drv2605_simpletest.py
@@ -16,16 +16,18 @@ drv = adafruit_drv2605.DRV2605(i2c)
 # Main loop runs forever trying each effect (1-117).
 # See table 11.2 in the datasheet for a list of all the effect names and IDs.
 #   http://www.ti.com/lit/ds/symlink/drv2605.pdf
-effect = 1
+effect_id = 1
 while True:
-    print('Playing effect #{0}'.format(effect))
-    drv.sequence[0] = effect  # Set the effect on slot 0.
+    print('Playing effect #{0}'.format(effect_id))
+    drv.sequence[0] = adafruit_drv2605.Effect(effect_id)  # Set the effect on slot 0.
     # You can assign effects to up to 7 different slots to combine
     # them in interesting ways. Index the sequence property with a
     # slot number 0 to 6.
+    # Optionally, you can assign a pause to a slot. E.g.
+    # drv.sequence[1] = adafruit_drv2605.Pause(5)  # Pause for 50 milliseconds
     drv.play()  # Play the effect.
     time.sleep(0.5)
     # Increment effect ID and wrap back around to 1.
-    effect += 1
-    if effect > 117:
-        effect = 1
+    effect_id += 1
+    if effect_id > 117:
+        effect_id = 1

--- a/examples/drv2605_simpletest.py
+++ b/examples/drv2605_simpletest.py
@@ -24,7 +24,7 @@ while True:
     # them in interesting ways. Index the sequence property with a
     # slot number 0 to 6.
     # Optionally, you can assign a pause to a slot. E.g.
-    # drv.sequence[1] = adafruit_drv2605.Pause(5)  # Pause for 50 milliseconds
+    # drv.sequence[1] = adafruit_drv2605.Pause(0.5)  # Pause for half a second
     drv.play()  # Play the effect.
     time.sleep(0.5)
     # Increment effect ID and wrap back around to 1.


### PR DESCRIPTION
Added an indexable `sequence` property for setting/getting waveform effects and pauses. Each of the 7 waveform slots takes either an `Effect` or `Pause` class. These classes perform argument value checking and conversion from/to human-readable values.

Example use:
```
Adafruit CircuitPython 3.0.2 on 2018-09-14; Adafruit Feather M0 Express with samd21g18
>>> import board
>>> import busio
>>> import adafruit_drv2605
>>> i2c = busio.I2C(board.SCL, board.SDA)
>>> drv = adafruit_drv2605.DRV2605(i2c)
>>> drv.sequence
[Effect(1), Effect(0), Effect(0), Effect(0), Effect(0), Effect(0), Effect(0)]
>>> drv.sequence[1] = adafruit_drv2605.Pause(0.5)
>>> drv.sequence
[Effect(1), Pause(0.5), Effect(0), Effect(0), Effect(0), Effect(0), Effect(0)]
>>> drv.sequence[2] = adafruit_drv2605.Effect(88)
>>> drv.sequence
[Effect(1), Pause(0.5), Effect(88), Effect(0), Effect(0), Effect(0), Effect(0)]
>>> drv.play()
```