### PR TITLE
Sure, loop on all 123.

### DIFF
--- a/examples/drv2605_simpletest.py
+++ b/examples/drv2605_simpletest.py
@@ -1,5 +1,5 @@
 # Simple demo of the DRV2605 haptic feedback motor driver.
-# Will play all 117 effects in order for about a half second each.
+# Will play all 123 effects in order for about a half second each.
 # Author: Tony DiCola
 import time
 
@@ -13,7 +13,7 @@ import adafruit_drv2605
 i2c = busio.I2C(board.SCL, board.SDA)
 drv = adafruit_drv2605.DRV2605(i2c)
 
-# Main loop runs forever trying each effect (1-117).
+# Main loop runs forever trying each effect (1-123).
 # See table 11.2 in the datasheet for a list of all the effect names and IDs.
 #   http://www.ti.com/lit/ds/symlink/drv2605.pdf
 effect_id = 1
@@ -25,9 +25,10 @@ while True:
     # slot number 0 to 6.
     # Optionally, you can assign a pause to a slot. E.g.
     # drv.sequence[1] = adafruit_drv2605.Pause(0.5)  # Pause for half a second
-    drv.play()  # Play the effect.
-    time.sleep(0.5)
+    drv.play()       # play the effect
+    time.sleep(0.5)  # for 0.5 seconds
+    drv.stop()       # and then stop (if it's still running)
     # Increment effect ID and wrap back around to 1.
     effect_id += 1
-    if effect_id > 117:
+    if effect_id > 123:
         effect_id = 1


### PR DESCRIPTION
Fix for #13. Worth testing - effect 118 is several seconds long which made last effects essentially not play. Simple fix for that as well. Tested and all good.
```python
Adafruit CircuitPython 3.1.2 on 2019-01-07; Adafruit ItsyBitsy M0 Express with samd21g18
>>> import drv2605_simpletest
Playing effect #1
Playing effect #2
Playing effect #3
### SNIP ###
Playing effect #117
Playing effect #118
Playing effect #119
Playing effect #120
Playing effect #121
Playing effect #122
Playing effect #123
```
![drv2605_test](https://user-images.githubusercontent.com/8755041/54783108-bf3fdd00-4bdd-11e9-9204-b24cc9f60fe8.jpg)
