### PR TITLE
Add functionality to set the Real-Time Playback value

### DIFF
--- a/adafruit_drv2605.py
+++ b/adafruit_drv2605.py
@@ -214,8 +214,9 @@ class DRV2605:
         switched to ``MODE_REALTIME``, the motor is driven continuously with an
         amplitude/direction determined by this value.
 
-        By default, the device interprets it as SIGNED (2s complement), and its exact
-        effect depends on other operating parameters.
+        By default, the device expects a SIGNED 8-bit integer, and its exact
+        effect depends on both the type of motor (ERM/LRA) and whether the device
+        is operating in open- or closed-loop (unidirectional/bidirectional) mode.
 
         See the datasheet for more information!
 
@@ -223,20 +224,26 @@ class DRV2605:
 
         .. code-block:: python
 
-            # Configure the output amplitude to 50%
-            drv.realtime_value = 64
-
-            # Buzz the motor briefly
+            # Start real-time playback
+            drv.realtime_value = 0
             drv.mode = adafruit_drv2605.MODE_REALTIME
-            time.sleep(0.25)
+
+            # Buzz the motor briefly at 50% and 100% amplitude
+            drv.realtime_value = 64
+            time.sleep(0.5)
+            drv.realtime_value = 127
+            time.sleep(0.5)
+
+            # Stop real-time playback
+            drv.realtime_value = 0
             drv.mode = adafruit_drv2605.MODE_INTTRIG
         """
         return self._read_u8(_DRV2605_REG_RTPIN)
 
     @realtime_value.setter
     def realtime_value(self, val: int) -> None:
-        if not 0 <= val <= 255:
-            raise ValueError("Real-Time Playback value must be a value within 0-255!")
+        if not -127 <= val <= 255:
+            raise ValueError("Real-Time Playback value must be a value between -127 and 255!")
         self._write_u8(_DRV2605_REG_RTPIN, val)
 
     def set_waveform(self, effect_id: int, slot: int = 0) -> None:

--- a/adafruit_drv2605.py
+++ b/adafruit_drv2605.py
@@ -209,7 +209,10 @@ class DRV2605:
         return self._sequence
 
     def set_realtime_value(self, val: int) -> None:
-        """Set the output value (amplitude) used for Real-Time Playback"""
+        """Set the output value used for Real-Time Playback. By default, the device
+        interprets the value as SIGNED (2s complement), and its effect depends on
+        other operating parameters. Consult the datasheet for more information!
+        """
         if not 0 <= val <= 255:
             raise ValueError("Real-Time Playback value must be a value within 0-255!")
         self._write_u8(_DRV2605_REG_RTPIN, val)

--- a/adafruit_drv2605.py
+++ b/adafruit_drv2605.py
@@ -243,7 +243,7 @@ class DRV2605:
     @realtime_value.setter
     def realtime_value(self, val: int) -> None:
         if not -127 <= val <= 255:
-            raise ValueError("Real-Time Playback value must be a value between -127 and 255!")
+            raise ValueError("Real-Time Playback value must be between -127 and 255!")
         self._write_u8(_DRV2605_REG_RTPIN, val)
 
     def set_waveform(self, effect_id: int, slot: int = 0) -> None:

--- a/adafruit_drv2605.py
+++ b/adafruit_drv2605.py
@@ -208,6 +208,12 @@ class DRV2605:
         """
         return self._sequence
 
+    def set_realtime_value(self, val: int) -> None:
+        """Set the output value (amplitude) used for Real-Time Playback"""
+        if not 0 <= val <= 255:
+            raise ValueError("Real-Time Playback value must be a value within 0-255!")
+        self._write_u8(_DRV2605_REG_RTPIN, val)
+
     def set_waveform(self, effect_id: int, slot: int = 0) -> None:
         """Select an effect waveform for the specified slot (default is slot 0,
         but up to 8 effects can be combined with slot values 0 to 7).  See the

--- a/adafruit_drv2605.py
+++ b/adafruit_drv2605.py
@@ -208,11 +208,33 @@ class DRV2605:
         """
         return self._sequence
 
-    def set_realtime_value(self, val: int) -> None:
-        """Set the output value used for Real-Time Playback. By default, the device
-        interprets the value as SIGNED (2s complement), and its effect depends on
-        other operating parameters. Consult the datasheet for more information!
+    @property
+    def realtime_value(self) -> int:
+        """The output value used in Real-Time Playback mode. When the device is
+        switched to ``MODE_REALTIME``, the motor is driven continuously with an
+        amplitude/direction determined by this value.
+
+        By default, the device interprets it as SIGNED (2s complement), and its exact
+        effect depends on other operating parameters.
+
+        See the datasheet for more information!
+
+        E.g.:
+
+        .. code-block:: python
+
+            # Configure the output amplitude to 50%
+            drv.realtime_value = 64
+
+            # Buzz the motor briefly
+            drv.mode = adafruit_drv2605.MODE_REALTIME
+            time.sleep(0.25)
+            drv.mode = adafruit_drv2605.MODE_INTTRIG
         """
+        return self._read_u8(_DRV2605_REG_RTPIN)
+
+    @realtime_value.setter
+    def realtime_value(self, val: int) -> None:
         if not 0 <= val <= 255:
             raise ValueError("Real-Time Playback value must be a value within 0-255!")
         self._write_u8(_DRV2605_REG_RTPIN, val)


### PR DESCRIPTION
This PR adds the ability to set the output value in Real-Time Playback mode. A port of [this function](https://github.com/adafruit/Adafruit_DRV2605_Library/commit/abeb0c96c4d8690b0f112bb3ee7f2491c3b72f2d) from the DRV2605(L) Arduino library.

Closes #33